### PR TITLE
FIX. Allow owned forked frappe repo for Frappe App

### DIFF
--- a/development/installer.sh
+++ b/development/installer.sh
@@ -108,7 +108,7 @@ init_bench() {
   fi
 
   nvm use "$NODE_VERSION"
-  PYENV_VERSION="$PYENV_VERSION" bench init --skip-redis-config-generation --frappe-branch "$branch" --python "$python_version" "$bench_name"
+  PYENV_VERSION="$PYENV_VERSION" bench init --skip-redis-config-generation --frappe-path "$upstream" --frappe-branch "$branch" --python "$python_version" "$bench_name"
   cd "$bench_name" || exit
 
   echo "Setting up config"


### PR DESCRIPTION
Frappe is the only app that didn't allowed the use of $forked or $upstream parameters defined within apps.json, it was only working the $branch parameter because it uses a different approach than the other apps for installing within the script.

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
